### PR TITLE
refactor: Change terminology used in certain traits to make them less likely to have typos/confusion

### DIFF
--- a/methods/cheqd.json
+++ b/methods/cheqd.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://identity.foundation/did-traits/schemas/traits.json",
   "name": "cheqd",
-  "updateable": true,
+  "supportsUpdate": true,
   "updateableServiceEndpoints": true,
   "supportsDeactivate": true,
   "deletable": false,

--- a/methods/cheqd.json
+++ b/methods/cheqd.json
@@ -7,7 +7,7 @@
   "supportsDelete": false,
   "transactionalFees": true,
   "selfCertifying": false,
-  "updateableVerificationMethods": true,
+  "supportsUpdateVerificationMethods": true,
   "prerotationOfKeys": false,
   "multisigVerificationMethod": true,
   "humanreadable": false,

--- a/methods/cheqd.json
+++ b/methods/cheqd.json
@@ -10,7 +10,7 @@
   "supportsUpdateVerificationMethods": true,
   "prerotationOfKeys": false,
   "multisigVerificationMethod": true,
-  "humanreadable": false,
+  "humanReadable": false,
   "enumerable": true,
   "resolvableLocally": false,
   "resolvableGlobally": true,

--- a/methods/cheqd.json
+++ b/methods/cheqd.json
@@ -4,7 +4,7 @@
   "supportsUpdate": true,
   "supportsUpdateServiceEndpoints": true,
   "supportsDeactivate": true,
-  "deletable": false,
+  "supportsDelete": false,
   "transactionalFees": true,
   "selfCertifying": false,
   "updateableVerificationMethods": true,

--- a/methods/cheqd.json
+++ b/methods/cheqd.json
@@ -2,7 +2,7 @@
   "$schema": "https://identity.foundation/did-traits/schemas/traits.json",
   "name": "cheqd",
   "supportsUpdate": true,
-  "updateableServiceEndpoints": true,
+  "supportsUpdateServiceEndpoints": true,
   "supportsDeactivate": true,
   "deletable": false,
   "transactionalFees": true,

--- a/methods/cheqd.json
+++ b/methods/cheqd.json
@@ -3,7 +3,7 @@
   "name": "cheqd",
   "updateable": true,
   "updateableServiceEndpoints": true,
-  "deactivatable": true,
+  "supportsDeactivate": true,
   "deletable": false,
   "transactionalFees": true,
   "selfCertifying": false,

--- a/methods/iden3.json
+++ b/methods/iden3.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://identity.foundation/did-traits/schemas/traits.json",
   "name": "iden3",
-  "updateable": true,
+  "supportsUpdate": true,
   "updateableServiceEndpoints": true,
   "supportsDeactivate": true,
   "deletable": false,

--- a/methods/iden3.json
+++ b/methods/iden3.json
@@ -7,7 +7,7 @@
   "supportsDelete": false,
   "transactionalFees": true,
   "selfCertifying": false,
-  "updateableVerificationMethods": true,
+  "supportsUpdateVerificationMethods": true,
   "prerotationOfKeys": false,
   "multisigVerificationMethod": false,
   "humanreadable": false,

--- a/methods/iden3.json
+++ b/methods/iden3.json
@@ -10,7 +10,7 @@
   "supportsUpdateVerificationMethods": true,
   "prerotationOfKeys": false,
   "multisigVerificationMethod": false,
-  "humanreadable": false,
+  "humanReadable": false,
   "enumerable": false,
   "resolvableLocally": false,
   "resolvableGlobally": true,

--- a/methods/iden3.json
+++ b/methods/iden3.json
@@ -4,7 +4,7 @@
   "supportsUpdate": true,
   "supportsUpdateServiceEndpoints": true,
   "supportsDeactivate": true,
-  "deletable": false,
+  "supportsDelete": false,
   "transactionalFees": true,
   "selfCertifying": false,
   "updateableVerificationMethods": true,

--- a/methods/iden3.json
+++ b/methods/iden3.json
@@ -3,7 +3,7 @@
   "name": "iden3",
   "updateable": true,
   "updateableServiceEndpoints": true,
-  "deactivatable": true,
+  "supportsDeactivate": true,
   "deletable": false,
   "transactionalFees": true,
   "selfCertifying": false,

--- a/methods/iden3.json
+++ b/methods/iden3.json
@@ -2,7 +2,7 @@
   "$schema": "https://identity.foundation/did-traits/schemas/traits.json",
   "name": "iden3",
   "supportsUpdate": true,
-  "updateableServiceEndpoints": true,
+  "supportsUpdateServiceEndpoints": true,
   "supportsDeactivate": true,
   "deletable": false,
   "transactionalFees": true,

--- a/methods/key.json
+++ b/methods/key.json
@@ -4,7 +4,7 @@
   "supportsUpdate": false,
   "supportsUpdateServiceEndpoints": false,
   "supportsDeactivate": false,
-  "deletable": false,
+  "supportsDelete": false,
   "transactionalFees": false,
   "selfCertifying": true,
   "updateableVerificationMethods": false,

--- a/methods/key.json
+++ b/methods/key.json
@@ -2,7 +2,7 @@
   "$schema": "https://identity.foundation/did-traits/schemas/traits.json",
   "name": "key",
   "supportsUpdate": false,
-  "updateableServiceEndpoints": false,
+  "supportsUpdateServiceEndpoints": false,
   "supportsDeactivate": false,
   "deletable": false,
   "transactionalFees": false,

--- a/methods/key.json
+++ b/methods/key.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://identity.foundation/did-traits/schemas/traits.json",
   "name": "key",
-  "updateable": false,
+  "supportsUpdate": false,
   "updateableServiceEndpoints": false,
   "supportsDeactivate": false,
   "deletable": false,

--- a/methods/key.json
+++ b/methods/key.json
@@ -3,7 +3,7 @@
   "name": "key",
   "updateable": false,
   "updateableServiceEndpoints": false,
-  "deactivatable": false,
+  "supportsDeactivate": false,
   "deletable": false,
   "transactionalFees": false,
   "selfCertifying": true,

--- a/methods/key.json
+++ b/methods/key.json
@@ -7,7 +7,7 @@
   "supportsDelete": false,
   "transactionalFees": false,
   "selfCertifying": true,
-  "updateableVerificationMethods": false,
+  "supportsUpdateVerificationMethods": false,
   "prerotationOfKeys": false,
   "multisigVerificationMethod": false,
   "humanreadable": false,

--- a/methods/key.json
+++ b/methods/key.json
@@ -10,7 +10,7 @@
   "supportsUpdateVerificationMethods": false,
   "prerotationOfKeys": false,
   "multisigVerificationMethod": false,
-  "humanreadable": false,
+  "humanReadable": false,
   "enumerable": false,
   "resolvableLocally": false,
   "resolvableGlobally": true,

--- a/methods/peer.json
+++ b/methods/peer.json
@@ -4,7 +4,7 @@
   "supportsUpdate": true,
   "supportsUpdateServiceEndpoints": true,
   "supportsDeactivate": false,
-  "deletable": false,
+  "supportsDelete": false,
   "transactionalFees": false,
   "selfCertifying": true,
   "updateableVerificationMethods": true,

--- a/methods/peer.json
+++ b/methods/peer.json
@@ -2,7 +2,7 @@
   "$schema": "https://identity.foundation/did-traits/schemas/traits.json",
   "name": "peer",
   "supportsUpdate": true,
-  "updateableServiceEndpoints": true,
+  "supportsUpdateServiceEndpoints": true,
   "supportsDeactivate": false,
   "deletable": false,
   "transactionalFees": false,

--- a/methods/peer.json
+++ b/methods/peer.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://identity.foundation/did-traits/schemas/traits.json",
   "name": "peer",
-  "updateable": true,
+  "supportsUpdate": true,
   "updateableServiceEndpoints": true,
   "supportsDeactivate": false,
   "deletable": false,

--- a/methods/peer.json
+++ b/methods/peer.json
@@ -3,7 +3,7 @@
   "name": "peer",
   "updateable": true,
   "updateableServiceEndpoints": true,
-  "deactivatable": false,
+  "supportsDeactivate": false,
   "deletable": false,
   "transactionalFees": false,
   "selfCertifying": true,

--- a/methods/peer.json
+++ b/methods/peer.json
@@ -10,7 +10,7 @@
   "supportsUpdateVerificationMethods": true,
   "prerotationOfKeys": false,
   "multisigVerificationMethod": false,
-  "humanreadable": false,
+  "humanReadable": false,
   "enumerable": false,
   "resolvableLocally": true,
   "resolvableGlobally": false,

--- a/methods/peer.json
+++ b/methods/peer.json
@@ -7,7 +7,7 @@
   "supportsDelete": false,
   "transactionalFees": false,
   "selfCertifying": true,
-  "updateableVerificationMethods": true,
+  "supportsUpdateVerificationMethods": true,
   "prerotationOfKeys": false,
   "multisigVerificationMethod": false,
   "humanreadable": false,

--- a/methods/web.json
+++ b/methods/web.json
@@ -10,7 +10,7 @@
   "supportsUpdateVerificationMethods": true,
   "prerotationOfKeys": false,
   "multisigVerificationMethod": false,
-  "humanreadable": true,
+  "humanReadable": true,
   "enumerable": false,
   "resolvableLocally": false,
   "resolvableGlobally": true,

--- a/methods/web.json
+++ b/methods/web.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://identity.foundation/did-traits/schemas/traits.json",
   "name": "web",
-  "updateable": true,
+  "supportsUpdate": true,
   "updateableServiceEndpoints": true,
   "supportsDeactivate": true,
   "deletable": true,

--- a/methods/web.json
+++ b/methods/web.json
@@ -4,7 +4,7 @@
   "supportsUpdate": true,
   "supportsUpdateServiceEndpoints": true,
   "supportsDeactivate": true,
-  "deletable": true,
+  "supportsDelete": true,
   "transactionalFees": false,
   "selfCertifying": false,
   "updateableVerificationMethods": true,

--- a/methods/web.json
+++ b/methods/web.json
@@ -7,7 +7,7 @@
   "supportsDelete": true,
   "transactionalFees": false,
   "selfCertifying": false,
-  "updateableVerificationMethods": true,
+  "supportsUpdateVerificationMethods": true,
   "prerotationOfKeys": false,
   "multisigVerificationMethod": false,
   "humanreadable": true,

--- a/methods/web.json
+++ b/methods/web.json
@@ -3,7 +3,7 @@
   "name": "web",
   "updateable": true,
   "updateableServiceEndpoints": true,
-  "deactivatable": true,
+  "supportsDeactivate": true,
   "deletable": true,
   "transactionalFees": false,
   "selfCertifying": false,

--- a/methods/web.json
+++ b/methods/web.json
@@ -2,7 +2,7 @@
   "$schema": "https://identity.foundation/did-traits/schemas/traits.json",
   "name": "web",
   "supportsUpdate": true,
-  "updateableServiceEndpoints": true,
+  "supportsUpdateServiceEndpoints": true,
   "supportsDeactivate": true,
   "deletable": true,
   "transactionalFees": false,

--- a/methods/webvh.json
+++ b/methods/webvh.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://identity.foundation/did-traits/schemas/traits.json",
   "name": "webvh",
-  "updateable": true,
+  "supportsUpdate": true,
   "updateableServiceEndpoints": true,
   "supportsDeactivate": true,
   "deletable": true,

--- a/methods/webvh.json
+++ b/methods/webvh.json
@@ -4,7 +4,7 @@
   "supportsUpdate": true,
   "supportsUpdateServiceEndpoints": true,
   "supportsDeactivate": true,
-  "deletable": true,
+  "supportsDelete": true,
   "transactionalFees": false,
   "selfCertifying": true,
   "updateableVerificationMethods": true,

--- a/methods/webvh.json
+++ b/methods/webvh.json
@@ -3,7 +3,7 @@
   "name": "webvh",
   "updateable": true,
   "updateableServiceEndpoints": true,
-  "deactivatable": true,
+  "supportsDeactivate": true,
   "deletable": true,
   "transactionalFees": false,
   "selfCertifying": true,

--- a/methods/webvh.json
+++ b/methods/webvh.json
@@ -2,7 +2,7 @@
   "$schema": "https://identity.foundation/did-traits/schemas/traits.json",
   "name": "webvh",
   "supportsUpdate": true,
-  "updateableServiceEndpoints": true,
+  "supportsUpdateServiceEndpoints": true,
   "supportsDeactivate": true,
   "deletable": true,
   "transactionalFees": false,

--- a/methods/webvh.json
+++ b/methods/webvh.json
@@ -10,7 +10,7 @@
   "supportsUpdateVerificationMethods": true,
   "prerotationOfKeys": true,
   "multisigVerificationMethod": false,
-  "humanreadable": false,
+  "humanReadable": false,
   "enumerable": false,
   "resolvableLocally": false,
   "resolvableGlobally": true,

--- a/methods/webvh.json
+++ b/methods/webvh.json
@@ -7,7 +7,7 @@
   "supportsDelete": true,
   "transactionalFees": false,
   "selfCertifying": true,
-  "updateableVerificationMethods": true,
+  "supportsUpdateVerificationMethods": true,
   "prerotationOfKeys": true,
   "multisigVerificationMethod": false,
   "humanreadable": false,

--- a/schemas/traits.json
+++ b/schemas/traits.json
@@ -20,10 +20,10 @@
       "title": "Updateable Service Endpoints",
       "description": "Service endpoints are updateable, see https://w3c.github.io/did-core/#services."
     },
-    "deactivatable": {
+    "supportsDeactivate": {
       "type": "boolean",
-      "title": "Deactivatable",
-      "description": "DIDs are deactivatable, see https://w3c.github.io/did-core/#method-operations."
+      "title": "Deactivate supported?",
+      "description": "DIDs can be deactivated, see https://w3c.github.io/did-core/#method-operations."
     },
     "deletable": {
       "type": "boolean",

--- a/schemas/traits.json
+++ b/schemas/traits.json
@@ -40,10 +40,10 @@
       "title": "Self-Certifying",
       "description": "DID method where the cryptographic material used to generate the DID is embedded within the identifier itself, creating an inherent and verifiable cryptographic binding between the DID, its initial DID document, and the associated cryptographic keys. This approach eliminates the need for external verification infrastructure, as the identifier's authenticity can be cryptographically validated through its own intrinsic key material."
     },
-    "updateableVerificationMethods": {
+    "supportsUpdateVerificationMethods": {
       "type": "boolean",
-      "title": "Rotatable Verification Methods",
-      "description": "Verification methods are updateable, allowing cryptographic keys to be replaced or updated, see https://w3c.github.io/did-core/#verification-methods."
+      "title": "Verification Methods can be updated?",
+      "description": "Verification methods can be updated, allowing cryptographic keys to be replaced or updated, see https://w3c.github.io/did-core/#verification-methods."
     },
     "prerotationOfKeys": {
       "type": "boolean",

--- a/schemas/traits.json
+++ b/schemas/traits.json
@@ -25,10 +25,10 @@
       "title": "Deactivate supported?",
       "description": "DIDs can be deactivated, see https://w3c.github.io/did-core/#method-operations."
     },
-    "deletable": {
+    "supportsDelete": {
       "type": "boolean",
-      "title": "Deletable",
-      "description": "DID method's capability to permanently remove a DID and its associated DID document from the underlying system, rendering the identifier and its historical irresolvable."
+      "title": "Delete supported?",
+      "description": "DID method's capability to permanently remove a DID and its associated DID document from the underlying system, rendering the identifier and its history unresolvable."
     },
     "transactionalFees": {
       "type": "boolean",

--- a/schemas/traits.json
+++ b/schemas/traits.json
@@ -55,7 +55,7 @@
       "title": "Multi-Signature Verification Method",
       "description": "A DID method that supports distributed control of a decentralized identifier through a cryptographic mechanism requiring multiple independent signatures to authorize critical identity operations such as updating, deactivating or using the DID."
     },
-    "humanreadable": {
+    "humanReadable": {
       "type": "boolean",
       "title": "Human-readable",
       "description": "A DID method's ability to generate identifiers that are cognitively accessible and memorable to humans, typically incorporating meaningful, domain-specific, or intuitive components."

--- a/schemas/traits.json
+++ b/schemas/traits.json
@@ -82,7 +82,7 @@
     },
     "historySigned": {
       "type": "boolean",
-      "title": "Cryptograhpically signed DID Document History",
+      "title": "Cryptographically signed DID Document History",
       "description": "A DID method's capability to record all modifications to the DID document in an append-only, cryptographically verifiable data structure that prevents retroactive alteration or deletion of historical states."
     },
     "hostingNotRequired": {
@@ -103,12 +103,12 @@
     "cryptographyPrivacyPreservingBBSPlus": {
       "type": "boolean",
       "title": "Privacy Preserving Crypto - BBS+",
-      "description": "A DID method’s ability to use cryptographic techniques that enable identity verification and authentication while minimizing the disclosure of sensitive personal information. Specifically by using the Selective Disclosure techniques of the BBS+ scheme as standardized in the IETF CFRG https://datatracker.ietf.org/doc/draft-irtf-cfrg-bbs-signatures/."
+      "description": "A DID method's ability to use cryptographic techniques that enable identity verification and authentication while minimizing the disclosure of sensitive personal information. Specifically by using the Selective Disclosure techniques of the BBS+ scheme as standardized in the IETF CFRG https://datatracker.ietf.org/doc/draft-irtf-cfrg-bbs-signatures/."
     },
     "cryptographyPrivacyPreservingNiZKPs": {
       "type": "boolean",
       "title": "Privacy Preserving Crypto - niZKPs",
-      "description": "A DID method’s ability to use cryptographic techniques that enable identity verification and authentication while minimizing the disclosure of sensitive personal information. Using other cryptography that supports Non-interactive Zero Knowledge Proofs (niZKPs) such as zk-SNARKS, zk-STARKS, Bulletproofs or other similar zero knowledge protocol types."
+      "description": "A DID method's ability to use cryptographic techniques that enable identity verification and authentication while minimizing the disclosure of sensitive personal information. Using other cryptography that supports Non-interactive Zero Knowledge Proofs (niZKPs) such as zk-SNARKS, zk-STARKS, Bulletproofs or other similar zero knowledge protocol types."
     },
     "cryptographicAlgorithmRsa2048": {
       "type": "boolean",

--- a/schemas/traits.json
+++ b/schemas/traits.json
@@ -10,10 +10,10 @@
       "description": "DID Method Name, see https://w3c.github.io/did-core/#did-syntax.",
       "pattern": "^[a-z0-9]+$"
     },
-    "updateable": {
+    "supportsUpdate": {
       "type": "boolean",
-      "title": "Updateable",
-      "description": "DID Documents are updateable, see https://w3c.github.io/did-core/#method-operations."
+      "title": "Update supported?",
+      "description": "DID Documents can be updated, see https://w3c.github.io/did-core/#method-operations."
     },
     "updateableServiceEndpoints": {
       "type": "boolean",

--- a/schemas/traits.json
+++ b/schemas/traits.json
@@ -15,10 +15,10 @@
       "title": "Update supported?",
       "description": "DID Documents can be updated, see https://w3c.github.io/did-core/#method-operations."
     },
-    "updateableServiceEndpoints": {
+    "supportsUpdateServiceEndpoints": {
       "type": "boolean",
-      "title": "Updateable Service Endpoints",
-      "description": "Service endpoints are updateable, see https://w3c.github.io/did-core/#services."
+      "title": "Service Endpoints can be updated?",
+      "description": "Service Endpoints can be updated, see https://w3c.github.io/did-core/#services."
     },
     "supportsDeactivate": {
       "type": "boolean",


### PR DESCRIPTION
This PR suggests a resolution to the issues raised under #38. It contains the following changes:

- `deactivatable` -> `supportsDeactivate`
- `updateable` -> `supportsUpdate`
- `updateableServiceEndpoints` -> `supportsUpdateServiceEndpoints`
- `deletable` -> `supportsDelete`
- `updateableVerificationMethods` -> `supportsUpdateVerificationMethods`
- `humanreadable` -> `humanReadable` (not mentioned in that issue, but since I'm at it, I wanted to fix this to the more commonly formatted version in snakeCase)

I've also updated the title and descriptions accordingly to match the new property names, and updated it in the `traits.json` file for all methods. I've fixed a few other typo/copyedits in the descriptions as well.

I have **not** changed the contents of `schema/v0.8.0/traits.json` as this is a ratified version and I don't want to change that without asking. IMO, it's up to the chairs (**if** this PR is to be accepted) to decide whether to:

1. Leave v0.8.0 as-is, since it's the ratified version. These new property names will go into effect with the next version. (Risk: these "legacy" names get implemented in software or otherwise, and therefore the impact of this becomes a "breaking" change.)
2. Change it both in the current working `traits.json` as well as the v0.8.0 schema. The justification might be that these are copyedits (same as when fixing typos), rather than introducing fundamentally new properties or changing the definition of the traits altogether (the definition remains the same).

(There's of course a 3rd option, which is to reject this PR altogether or maybe only cherry-pick the non-renaming changes. That will tie in to the outcome on discussion of #38.)