### PR TITLE
Fix did trait wording descriptions

### DIFF
--- a/schemas/traits.json
+++ b/schemas/traits.json
@@ -7,7 +7,7 @@
     "name": {
       "type": "string",
       "title": "DID Method Name",
-      "description": "A DID Method with a properly defined Name, see https://w3c.github.io/did-core/#did-syntax.",
+      "description": "DID Method Name, see https://w3c.github.io/did-core/#did-syntax.",
       "pattern": "^[a-z0-9]+$"
     },
     "supportsUpdate": {


### PR DESCRIPTION
Fixes the descriptions of the did traits so that wording is consistent in the form "A DID method....", addresses https://github.com/decentralized-identity/did-traits/issues/56